### PR TITLE
Fix helm init due to syntax error

### DIFF
--- a/plugin/helm/helm
+++ b/plugin/helm/helm
@@ -57,8 +57,7 @@ EOF
 {"spec":
 ${KUBECTL_PLUGINS_LOCAL_FLAG_REPO:+"repoUrl": $KUBECTL_PLUGINS_LOCAL_FLAG_REPO}
 ${KUBECTL_PLUGINS_LOCAL_FLAG_VERSION:+"version": $KUBECTL_PLUGINS_LOCAL_FLAG_VERSION}
-${values:+"values": "$(echo $values | json_escape)"}
-}
+${values:+"values": "$(echo $values | json_escape)"}}
 EOF
         kubectl patch helmrelease $name -p "$patch"
         ;;


### PR DESCRIPTION
Following the installation instructions, I get the following error
```
$ kubectl plugin helm init
./helm: line 61: syntax error near unexpected token `}'
error: exit status 2
```