### PR TITLE
Fix helm plugin parse error on bash, and other improvements

### DIFF
--- a/plugin/helm/helm
+++ b/plugin/helm/helm
@@ -2,7 +2,7 @@
 
 set -e
 test $KUBECTL_PLUGINS_GLOBAL_FLAG_V -gt 4 && set -x
-alias kubectl="$KUBECTL_PLUGINS_CALLER -n $KUBECTL_PLUGINS_CURRENT_NAMESPACE"
+alias kubectl="$KUBECTL_PLUGINS_CALLER -n $KUBECTL_PLUGINS_CURRENT_NAMESPACE -v=$KUBECTL_PLUGINS_GLOBAL_FLAG_V"
 
 values_yaml() {
     if [ "$KUBECTL_PLUGINS_LOCAL_FLAG_VALUES" != "" ]; then
@@ -53,14 +53,18 @@ EOF
         name="$1"; shift
 
         values=$(values_yaml)
-        patch=$(cat <<EOF)
-{"spec":
-${KUBECTL_PLUGINS_LOCAL_FLAG_REPO:+"repoUrl": $KUBECTL_PLUGINS_LOCAL_FLAG_REPO}
-${KUBECTL_PLUGINS_LOCAL_FLAG_VERSION:+"version": $KUBECTL_PLUGINS_LOCAL_FLAG_VERSION}
-${values:+"values": "$(echo $values | json_escape)"}
-}
+        q=\"
+        patch=$(cat <<EOF
+{"metadata": {"annotations": {"helm.bitnami.com/k8s-53379-workaround": "$(date +%s)"}}},
+{"spec": {
+${KUBECTL_PLUGINS_LOCAL_FLAG_VERSION:+${q}version${q}: ${q}$KUBECTL_PLUGINS_LOCAL_FLAG_VERSION${q},}
+${values:+${q}values${q}: ${q}$(echo $values | json_escape)${q},}
+"repoUrl": "$KUBECTL_PLUGINS_LOCAL_FLAG_REPO"
+}}
 EOF
-        kubectl patch helmrelease $name -p "$patch"
+             )
+        # NB: --type=strategic is broken for CRDs (k8s v1.8)
+        kubectl patch helmrelease $name -p "$patch" --type=merge
         ;;
 
     delete)

--- a/plugin/helm/plugin.yaml
+++ b/plugin/helm/plugin.yaml
@@ -1,5 +1,14 @@
 name: helm
 shortDesc: Helm chart plugin
+longDesc: |
+  The Kubernetes package manager (CRD version)
+
+  To begin working with Helm, run the command:
+
+          $ kubectl plugin helm init
+
+  This will install Tiller and the helm-crd controller to your running
+  Kubernetes cluster.
 tree:
   - name: init
     shortDesc: initialize Helm-CRD on server
@@ -38,7 +47,7 @@ tree:
         desc: specify values in a YAML file
       - name: set
         desc: >-
-          set values on the command line (can specify separate
+          set values on the command line (can specify multiple or separate
           values with commas: key1=val1,key2=val2)
 
   - name: upgrade


### PR DESCRIPTION
The following construct works on `dash`, but is a parse error on
`bash`.  Fixed in this change.
```sh
foo=$(cat <<EOF)
EOF
```

Fixes #17

Other improvements:
- Added long help description to `kubectl plugin helm`
- Fixed JSON quoting in `upgrade` subcommand
- Added workaround for kubernetes/kubernetes#53379
- Avoid strategic merge patch, which doesn't work with CRDs in k8s 1.8.